### PR TITLE
PR: Fix issue where process failed to start on Windows

### DIFF
--- a/src/spyder_updater/gui/updater.py
+++ b/src/spyder_updater/gui/updater.py
@@ -416,7 +416,7 @@ class Updater(QDialog):
 
         # Final command assembly
         if os.name == 'nt':
-            cmd = ['start', '"Update Spyder"'] + sub_cmd
+            cmd = ['cmd', '/c'] + sub_cmd
         elif sys.platform == "darwin":
             cmd = [shutil.which("zsh")] + sub_cmd
         else:


### PR DESCRIPTION
The subprocess command should not use "start" because this will launch another cmd window. The appropriate command is "cmd".