### PR TITLE
PR: Do not create checksum artifact

### DIFF
--- a/.github/workflows/build-updater.yml
+++ b/.github/workflows/build-updater.yml
@@ -94,11 +94,6 @@ jobs:
           mv $CONDA_BLD_PATH/noarch/*.conda .
           zip -mT spyder-updater *.lock *.conda
 
-      - name: Create Checksums
-        working-directory: ${{ env.DISTDIR }}
-        run: |
-          sha256sum spyder-updater.zip > Spyder-Updater-checksums.txt
-
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
With GitHub digest feature, we no longer need to create this artifact.

Wait for Spyder 7 before merging.

Fixes #6 