### PR TITLE
PR: Include "micro" in the update_type

### DIFF
--- a/src/spyder_updater/gui/assets/info-schema.json
+++ b/src/spyder_updater/gui/assets/info-schema.json
@@ -22,7 +22,7 @@
     "update_type": {
       "type": "string",
       "default": "minor",
-      "enum": ["minor", "major"],
+      "enum": ["micro", "minor", "major"],
       "description": "Type of update to be performed."
     },
     "window_title": {


### PR DESCRIPTION
fixes: `Update info doesn't contain the required fields to perform the update. Aborting!`

```
'micro' is not one of ['minor', 'major']

Failed validating 'enum' in schema['properties']['update_type']:
    {'type': 'string',
     'default': 'minor',
     'enum': ['minor', 'major'],
     'description': 'Type of update to be performed.'}

On instance['update_type']:
    'micro'
```