### PR TITLE
PR: Fix exit status of install.sh when start_spyder variable is not true

### DIFF
--- a/src/spyder_updater/scripts/install.sh
+++ b/src/spyder_updater/scripts/install.sh
@@ -65,4 +65,6 @@ launch_spyder(){
 
 wait_for_spyder_quit
 update_spyder
-[[ "$start_spyder" == "true" ]] && launch_spyder
+if [[ "$start_spyder" == "true" ]]; then
+    launch_spyder
+fi


### PR DESCRIPTION
Use an `if` block so that the exit status of `install.sh` does not reflect the `[[ "$start_spyder" == "true" ]]` conditional status.