### PR TITLE
PR: Exit install scripts on error

### DIFF
--- a/src/spyder_updater/scripts/install.bat
+++ b/src/spyder_updater/scripts/install.bat
@@ -18,11 +18,11 @@ rem Enforce encoding
 chcp 65001>nul
 
 call :wait_for_spyder_quit
-call :update_spyder
+call :update_spyder || goto :exit
 if "%start_spyder%"=="true" call :launch_spyder
 
 :exit
-    exit %ERRORLEVEL%
+    exit /b %ERRORLEVEL%
 
 :wait_for_spyder_quit
     echo Waiting for Spyder to quit...
@@ -40,11 +40,11 @@ if "%start_spyder%"=="true" call :launch_spyder
     pushd %installer_dir%
 
     echo Updating Spyder base environment...
-    %conda% update --name base --yes --file conda-base-win-64.lock
+    %conda% update --name base --yes --file conda-base-win-64.lock || exit /b %errorlevel%
 
     if "%rebuild%"=="true" (
         echo Rebuilding Spyder runtime environment...
-        %conda% remove --prefix %prefix% --all --yes
+        %conda% remove --prefix %prefix% --all --yes || exit /b %errorlevel%
         mkdir %prefix%\Menu
         echo. > "%prefix%\Menu\conda-based-app"
         set conda_cmd=create
@@ -52,7 +52,7 @@ if "%start_spyder%"=="true" call :launch_spyder
         echo Updating Spyder runtime environment...
         set conda_cmd=update
     )
-    %conda% %conda_cmd% --prefix %prefix% --yes --file conda-runtime-win-64.lock
+    %conda% %conda_cmd% --prefix %prefix% --yes --file conda-runtime-win-64.lock || exit /b %errorlevel%
 
     echo Cleaning packages and temporary files...
     %conda% clean --yes --packages --tempfiles %prefix%

--- a/src/spyder_updater/scripts/install.sh
+++ b/src/spyder_updater/scripts/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 while getopts "i:c:p:rs" option; do
     case "$option" in
@@ -21,7 +22,6 @@ wait_for_spyder_quit(){
 }
 
 update_spyder(){
-    # Unzip installer file
     pushd $(dirname $install_file)
 
     # Determine OS type


### PR DESCRIPTION
Install scripts should exit immediately with error code if an error occurs when updating the base or runtime environments, and not proceed with the remainder of the script.