### PR TITLE
PR: Use a more fine-grained name to detect if Spyder is running

### DIFF
--- a/src/spyder_updater/scripts/install.sh
+++ b/src/spyder_updater/scripts/install.sh
@@ -13,7 +13,7 @@ done
 shift $(($OPTIND - 1))
 
 wait_for_spyder_quit(){
-    while [[ $(pgrep spyder 2> /dev/null) ]]; do
+    while [[ $(pgrep -f spyder-runtime/bin 2> /dev/null) ]]; do
         echo "Waiting for Spyder to quit..."
         sleep 1
     done


### PR DESCRIPTION
Right now we're using `pgrep spyder` to check if Spyder is still running before starting the update.

However, that matches the command used to run the updater on Linux, which in my case is:

> /home/carlos/.local/spyder-6/envs/spyder-updater/bin/python3.13 /home/carlos/.local/spyder-6/envs/spyder-updater/bin/spyder-updater --update-info-file /tmp/spyder-carlos/updates/6.1.0rc1/update-info.json --start-spyder

And that makes the updater wait indefinitely for itself to be closed.

So, if we use `pgrep spyder-runtime`, we shouldn't have this problem.