### PR TITLE
PR: Improve stdout text formatting

### DIFF
--- a/src/spyder_updater/gui/updater.py
+++ b/src/spyder_updater/gui/updater.py
@@ -280,6 +280,7 @@ class Updater(QDialog):
         self._streams_area = QPlainTextEdit(self)
         self._streams_area.setMinimumHeight(300)
         self._streams_area.setReadOnly(True)
+        self._streams_area.setLineWrapMode(QPlainTextEdit.NoWrap)
         streams_areda_css = qstylizer.style.StyleSheet()
         streams_areda_css.QPlainTextEdit.setValues(
             fontFamily=f"{self._update_info['monospace_font_family']}",
@@ -342,7 +343,8 @@ class Updater(QDialog):
     # -------------------------------------------------------------------------
     def _add_text_to_streams_area(self, text):
         self._streams_area.moveCursor(QTextCursor.End)
-        self._streams_area.appendHtml(text)
+        # Note appendPlainText starts new paragraph, so strip \n.
+        self._streams_area.appendPlainText(text.strip("\n"))
         self._streams_area.moveCursor(QTextCursor.End)
 
     def _when_update_is_done(self):


### PR DESCRIPTION
Use appendPlainText in order to retain stdout formatting.
Do not line wrap.

### Before

<img width="638" height="533" alt="Screenshot 2025-09-30 at 12 10 26 PM" src="https://github.com/user-attachments/assets/7d77dc11-b3d3-49f2-abea-3efe79d5890f" />

### After

<img width="639" height="532" alt="Screenshot 2025-09-30 at 12 09 54 PM" src="https://github.com/user-attachments/assets/9a999b08-73e2-422c-8765-506099275c63" />
