### PR TITLE
PR: Replace timeout with powershell sleep while waiting for Spyder to quit

### DIFF
--- a/src/spyder_updater/scripts/install.bat
+++ b/src/spyder_updater/scripts/install.bat
@@ -27,9 +27,9 @@ if "%start_spyder%"=="true" call :launch_spyder
 :wait_for_spyder_quit
     echo Waiting for Spyder to quit...
     :loop
-    tasklist /v /fi "ImageName eq pythonw.exe" /fo csv 2>NUL | find "Spyder">NUL
+    tasklist /v /fi "ImageName eq pythonw.exe" /fo csv 2>NUL | find "Spyder" >NUL
     IF "%ERRORLEVEL%"=="0" (
-        timeout /t 1 /nobreak > nul
+        C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -NonInteractive -Command "Start-Sleep -Seconds 1"
         goto loop
     )
     echo Spyder has quit.


### PR DESCRIPTION
Fix "ERROR: Input redirection is not supported, exiting the process immediately."

The timeout command cannot be used in non-interactive processes as it requires user input handling, resulting in the above error. stderr redirction (2>nul) will suppress the error message but timeout still exits immediately without waiting the timeout period, thus defeating the purpose.

Fixes: spyder-ide/spyder#26108